### PR TITLE
Add intake module skeleton

### DIFF
--- a/api/intake/route.ts
+++ b/api/intake/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server"
+import { submitIntake } from "@/apps/intake/actions"
+
+export async function POST(req: Request) {
+  const body = await req.json()
+  const job = await submitIntake(body)
+  return NextResponse.json(job)
+}

--- a/apps/intake/actions.ts
+++ b/apps/intake/actions.ts
@@ -1,0 +1,12 @@
+"use server"
+
+import { intakeSchema } from "./schema"
+import { processIntake } from "@/lib/ai/intake-agent"
+import { saveIntake } from "@/db/models/intake"
+
+export async function submitIntake(data: unknown) {
+  const parsed = intakeSchema.parse(data)
+  const job = await processIntake(parsed.rawInput)
+  await saveIntake(job)
+  return job
+}

--- a/apps/intake/form.tsx
+++ b/apps/intake/form.tsx
@@ -1,0 +1,71 @@
+"use client"
+import { useState, useRef } from "react"
+import { submitIntake } from "./actions"
+
+export function IntakeForm() {
+  const [input, setInput] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [recording, setRecording] = useState(false)
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
+
+  function toggleRecording() {
+    if (recording) {
+      recognitionRef.current?.stop()
+      setRecording(false)
+      return
+    }
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (!SpeechRecognition) {
+      alert("Speech recognition not supported")
+      return
+    }
+    const recognition = new SpeechRecognition()
+    recognition.lang = "en-US"
+    recognition.continuous = true
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const transcript = Array.from(event.results)
+        .map((r) => r[0].transcript)
+        .join(" ")
+      setInput((prev) => `${prev} ${transcript}`)
+    }
+    recognition.start()
+    recognitionRef.current = recognition
+    setRecording(true)
+  }
+
+  async function handleSubmit() {
+    setLoading(true)
+    await submitIntake({ rawInput: input })
+    setLoading(false)
+    setInput("")
+  }
+
+  return (
+    <div>
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="Describe your issue or record audio..."
+        className="w-full p-2 border rounded"
+      />
+      <div className="flex gap-2 mt-2">
+        <button
+          onClick={toggleRecording}
+          className="bg-gray-200 px-4 py-2 rounded"
+          type="button"
+        >
+          {recording ? "Stop" : "Record"}
+        </button>
+        <button
+          onClick={handleSubmit}
+          className="bg-black text-white px-4 py-2 rounded"
+          disabled={loading}
+          type="button"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/intake/i18n.ts
+++ b/apps/intake/i18n.ts
@@ -1,0 +1,18 @@
+export const messages = {
+  en: {
+    title: "Job Intake",
+    placeholder: "Describe your issue or record audio...",
+    submit: "Submit",
+    record: "Record",
+    stop: "Stop",
+  },
+  es: {
+    title: "Registro de Trabajo",
+    placeholder: "Describa su problema o grabe audio...",
+    submit: "Enviar",
+    record: "Grabar",
+    stop: "Detener",
+  },
+}
+
+export type SupportedLang = keyof typeof messages

--- a/apps/intake/page.tsx
+++ b/apps/intake/page.tsx
@@ -1,0 +1,10 @@
+import { IntakeForm } from "./form"
+
+export default function IntakePage() {
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Job Intake</h1>
+      <IntakeForm />
+    </div>
+  )
+}

--- a/apps/intake/schema.ts
+++ b/apps/intake/schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const intakeSchema = z.object({
+  rawInput: z.string().min(1, "Input is required"),
+})
+
+export type IntakeInput = z.infer<typeof intakeSchema>

--- a/apps/intake/types.ts
+++ b/apps/intake/types.ts
@@ -1,0 +1,7 @@
+export interface StructuredJob {
+  id: string
+  rawInput: string
+  issue: string
+  language: string
+  createdAt: string
+}

--- a/db/models/intake.ts
+++ b/db/models/intake.ts
@@ -1,0 +1,11 @@
+import { StructuredJob } from "@/apps/intake/types"
+
+const intakes: StructuredJob[] = []
+
+export async function saveIntake(data: StructuredJob) {
+  intakes.push(data)
+}
+
+export async function listIntakes() {
+  return intakes
+}

--- a/lib/ai/intake-agent.ts
+++ b/lib/ai/intake-agent.ts
@@ -1,0 +1,20 @@
+import { randomUUID } from "crypto"
+import { StructuredJob } from "@/apps/intake/types"
+
+function detectLanguage(text: string): string {
+  const spanishWords = ["el", "la", "que", "de", "y", "en", "un"]
+  const lowered = text.toLowerCase()
+  const hits = spanishWords.filter((w) => lowered.includes(w)).length
+  return hits > 2 ? "es" : "en"
+}
+
+export async function processIntake(rawInput: string): Promise<StructuredJob> {
+  const job: StructuredJob = {
+    id: randomUUID(),
+    rawInput,
+    issue: rawInput.trim(),
+    language: detectLanguage(rawInput),
+    createdAt: new Date().toISOString(),
+  }
+  return job
+}


### PR DESCRIPTION
## Summary
- add basic form with voice recording
- route server action to process intake
- add simple language detection AI agent and data model
- wire up API endpoint, schema, and i18n strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bdc7d429883319a3718d365244db4